### PR TITLE
Supprimer le footer (v2) - Application des règles de contribution

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -577,21 +577,6 @@ endif;
 					<span class="small"><?php echo I18n::_('In case this message never disappears please have a look at <a href="%s">this FAQ for information to troubleshoot</a>.', 'https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-the-loading-message-not-go-away'); ?></span>
 				</div>
 			</section>
-			<footer class="container">
-				<div class="row">
-					<h4 class="col-md-5 col-xs-8"><?php echo I18n::_($NAME); ?> <small>- <?php echo I18n::_('Because ignorance is bliss'); ?></small></h4>
-					<p class="col-md-1 col-xs-4 text-center"><?php echo $VERSION; ?></p>
-					<p id="aboutbox" class="col-md-6 col-xs-12">
-						<?php echo sprintf(
-                            I18n::_('%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.',
-                                I18n::_($NAME),
-                                '%s', '%s'
-                            ),
-                            '<i>', '</i>'), ' ', $INFO, PHP_EOL;
-                        ?>
-					</p>
-				</div>
-			</footer>
 		</main>
 <?php
 if ($DISCUSSION) :


### PR DESCRIPTION
## Description du problème résolu

Le footer actuel de CharleBin (ou PrivateBin) contient des informations obsolètes et peu pertinentes pour l'utilisateur. Il occupe de l'espace inutilement, en particulier sur les appareils mobiles, et nuit à la clarté de l'interface.

## Solution proposée
Cette Pull Request propose la suppression complète du footer. Cela permet de simplifier l'interface, d'optimiser l'espace disponible et de réduire la quantité de code à maintenir.

## Instructions pour tester

1. Clonez la branche supprimer-footer-v2.
2. Lancez l'application avec make start.
3. Accédez à la page d'accueil et à d'autres pages de CharleBin.
4. Vérifiez que le footer a bien été supprimé.
5. Assurez-vous qu'aucune fonctionnalité n'est affectée par la suppression du footer.

## Captures d'écran (si applicable)
Avant : 
![avant](https://github.com/user-attachments/assets/f22ec161-0e31-467a-b669-81c72928ed56)
Après : 
![apres](https://github.com/user-attachments/assets/7f3b973f-ed48-4d2a-8918-1b695b78ccaa)
